### PR TITLE
Don't use modifiable global variables in callbacks!

### DIFF
--- a/dve/app.py
+++ b/dve/app.py
@@ -178,14 +178,6 @@ def get_app(config, data):
         default = [minimum, maximum]
         return minimum, maximum, step, default
 
-    # TODO: Remove when no longer needed for development
-    # @app.callback(
-    #     Output("hover-data", "children"),
-    #     [Input("my-graph", "hoverData")]
-    # )
-    # def display_hover_data(hover_data):
-    #     return json.dumps(hover_data, indent=2)
-
     def value_table(*items):
         return dbc.Table(
             [
@@ -306,14 +298,6 @@ def get_app(config, data):
             ),
         ]
 
-    # TODO: Remove when no longer needed for development
-    # @app.callback(
-    #     Output("click-data", "children"),
-    #     [Input("my-graph", "clickData")]
-    # )
-    # def display_click_data(click_data):
-    #     return json.dumps(click_data, indent=2)
-
     # TODO: This can be better done by setting the "href" and "download"
     #   properties on a static download link established in layout.py.
     @app.callback(
@@ -414,9 +398,6 @@ def get_app(config, data):
                 selected_interp=interpolation_ctrl,
             ),
         ]
-
-    # TODO: What is this for? Remove?
-    ds = data[list(data.keys())[0]]["reconstruction"]
 
     # Bounds of Canada map
     cx_min = min(value for value in canada_x if value is not None)

--- a/dve/app.py
+++ b/dve/app.py
@@ -24,7 +24,7 @@ from dve.generate_iso_lines import lonlat_overlay
 
 import dash
 import dash_table
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, Output, State
 import dash_core_components as dcc
 import dash_html_components as html
 import dash_bootstrap_components as dbc
@@ -408,9 +408,11 @@ def get_app(config, data):
     @app.callback(
         Output("viewport-ds", "children"),
         [Input("my-graph", "relayoutData")],
+        [State("viewport-ds", "children")],
     )
-    def update_viewport(relayout_data):
-        # Save map viewport bounds when they change (zoom, pan events)
+    def update_viewport(relayout_data, prev_viewport):
+        # Save map viewport bounds when and only when they change
+        # (zoom, pan events)
         if relayout_data is not None and "xaxis.range[0]" in relayout_data:
             viewport = {
                 "x_min": relayout_data["xaxis.range[0]"],
@@ -419,7 +421,7 @@ def get_app(config, data):
                 "y_max": relayout_data["yaxis.range[1]"],
             }
             return json.dumps(viewport)
-
+        return prev_viewport
 
     @app.callback(
         Output("my-graph", "figure"),

--- a/dve/layout.py
+++ b/dve/layout.py
@@ -288,6 +288,19 @@ def table_C2_tab():
     )
 
 
+def internal_data():
+    """
+    Layout components for storing/sharing data between callbacks (and callback
+    invocations) on the client side, using a hidden div (ick!). See
+    https://dash.plotly.com/sharing-data-between-callbacks.
+
+    :return: List of components.
+    """
+    return [
+        html.Div(id="viewport-ds", style={'display': 'none'}),
+    ]
+
+
 def main(config, data):
     """
     Top-level layout component. `app.layout` should be set to the this value.
@@ -306,5 +319,6 @@ def main(config, data):
                 dbc.Col(dbc.Tabs([map_tab(config, data), table_C2_tab()])),
                 style={"margin-top": "1em"},
             ),
+            *internal_data(),
         ],
     )


### PR DESCRIPTION
Resolves #67 

Worth noting that per-client state that needs to be persisted between callbacks must be stored client-side. The hidden-div mechanism is icky, but it works and at present there are no alternatives.