### PR TITLE
Load data only on demand

### DIFF
--- a/dve/app.py
+++ b/dve/app.py
@@ -95,7 +95,7 @@ def get_app(config, data):
     app.title = "Pacific Climate Impacts Consortium Design Value Explorer"
     app.config.suppress_callback_exceptions = True
 
-    app.layout = dve.layout.main(config, data)
+    app.layout = dve.layout.main(config)
 
     @app.callback(
         [Output("table-C2-dv", "children"), Output("table", "children")],

--- a/dve/app.py
+++ b/dve/app.py
@@ -378,12 +378,12 @@ def get_app(config):
                 ("Lon", round(lon, 6)),
                 # (f"Z ({design_value_id_ctrl}) ({source})", round(z, 6)),
             ),
-            dv_table(
-                rlon,
-                rlat,
-                selected_dv=design_value_id_ctrl,
-                selected_interp=interpolation_ctrl,
-            ),
+            # dv_table(
+            #     rlon,
+            #     rlat,
+            #     selected_dv=design_value_id_ctrl,
+            #     selected_interp=interpolation_ctrl,
+            # ),
         ]
 
     # TODO: This can be better done by setting the "href" and "download"

--- a/dve/app.py
+++ b/dve/app.py
@@ -87,9 +87,6 @@ def get_app(config, data):
     )
 
     # initialize app
-    TIMEOUT = 60
-    server = flask.Flask("app")
-    app = dash.Dash("app", server=server)
     external_stylesheets = [dbc.themes.BOOTSTRAP]
     app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
     app.title = "Pacific Climate Impacts Consortium Design Value Explorer"
@@ -105,6 +102,7 @@ def get_app(config, data):
         name_and_units = (
             f"{design_value_id} ({config['dvs'][design_value_id]['units']})"
         )
+        # TODO: Use get_data here
         df = data[design_value_id]["table"]
         df = (
             df[["Location", "Prov", "lon", "lat", "PCIC", "NBCC 2015"]]

--- a/dve/data.py
+++ b/dve/data.py
@@ -12,11 +12,11 @@ def load_file(path):
     filename = resource_filename("dve", path)
     if path.endswith(".csv"):
         rv = pd.read_csv(filename)
-        logger.debug(f"   Loaded data from '{path}'")
+        logger.debug(f"Loaded data from '{path}'")
         return rv
     if path.endswith(".nc"):
         rv = read_data(filename)
-        logger.debug(f"   Loaded data from '{path}'")
+        logger.debug(f"Loaded data from '{path}'")
         return rv
     raise ValueError(f"Unrecognized file type in path '{path}'")
 

--- a/dve/data.py
+++ b/dve/data.py
@@ -11,9 +11,13 @@ def load_file(path):
     logger.info(f"Loading data from '{path}'")
     filename = resource_filename("dve", path)
     if path.endswith(".csv"):
-        return pd.read_csv(filename)
+        rv = pd.read_csv(filename)
+        logger.debug(f"   Loaded data from '{path}'")
+        return rv
     if path.endswith(".nc"):
-        return read_data(filename)
+        rv = read_data(filename)
+        logger.debug(f"   Loaded data from '{path}'")
+        return rv
     raise ValueError(f"Unrecognized file type in path '{path}'")
 
 

--- a/dve/layout.py
+++ b/dve/layout.py
@@ -221,12 +221,11 @@ def user_graph_interaction():
     ]
 
 
-def map_tab(config, data):
+def map_tab(config):
     """
     Top-level layout of map tab.
 
     :param config:
-    :param data:
     :return: dbc.Tab
     """
     colour_maps = config["map"]["colour_maps"]
@@ -249,7 +248,7 @@ def map_tab(config, data):
                     dbc.Col(
                         [
                             *overlay_options(),
-                            *colourbar_options(data, colour_maps),
+                            *colourbar_options(colour_maps),
                             *user_graph_interaction(),
                         ],
                         lg=5,
@@ -294,14 +293,10 @@ def internal_data():
     ]
 
 
-def main(config, data):
+def main(config):
     """
     Top-level layout component. `app.layout` should be set to the this value.
     """
-
-    # TODO: Replace the use of preloaded data with on-demand requests
-    #   for the data to be loaded.
-
     return dbc.Container(
         id="big-app-container",
         fluid=True,
@@ -309,7 +304,7 @@ def main(config, data):
         children=[
             *header(config),
             dbc.Row(
-                dbc.Col(dbc.Tabs([map_tab(config, data), table_C2_tab()])),
+                dbc.Col(dbc.Tabs([map_tab(config), table_C2_tab()])),
                 style={"margin-top": "1em"},
             ),
             *internal_data(),

--- a/dve/layout.py
+++ b/dve/layout.py
@@ -104,17 +104,11 @@ def overlay_options():
     ]
 
 
-def colourbar_options(data, colormaps):
+def colourbar_options(colormaps):
     """
     Layout for Colourbar Options section.
     This function returns a list of rows.
     """
-
-    (first_dv,) = data[list(data.keys())[0]]["reconstruction"].data_vars
-    first_rfield = data[list(data.keys())[0]]["reconstruction"][first_dv]
-    dmin = np.nanmin(first_rfield)
-    dmax = np.nanmax(first_rfield)
-    num_range_slider_steps = 10
 
     return [
         # Section title


### PR DESCRIPTION
Resolves #76 
Resolves #41 

This PR substitutes a memoized data-loading function for all uses of the global preloaded data variable `data`. This does not solve all data-loading issues, but it is a useful step towards that.

One disadvantage of the on-demand strategy is that the hover function breaks. As a temporary solution (possibly permanent), the data display has been removed, leaving only lon-lat. See issue #77.