### PR TITLE
Upgrade plotly, Dash; install orjson

### DIFF
--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -153,8 +153,7 @@ def add(app, config):
         icymin = find_nearest_index(rlat.values, cy_min)
         icymax = find_nearest_index(rlat.values, cy_max)
 
-        # TODO: Why copy?
-        ds_arr = dv.values[icymin:icymax, icxmin:icxmax].copy()
+        ds_arr = dv.values[icymin:icymax, icxmin:icxmax]
 
         if historical_dataset_id == "model" and mask_on:
             mask = native_mask[icymin:icymax, icxmin:icxmax]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ cligj==0.5.0
 -e git+https://github.com/pacificclimate/climpyrical.git#egg=climpyrical
 cycler==0.10.0
 cython
-dash==1.12.0
-dash-bootstrap-components==0.9.2
-dash-core-components==1.10.0
+dash==1.21.0
+dash-bootstrap-components==0.12.2
+dash-core-components==1.17.1
 dash-daq==0.5.0
-dash-html-components==1.0.3
-dash-renderer==1.4.1
-dash-table==4.7.0
+dash-html-components==1.1.4
+dash-renderer==1.9.1
+dash-table==4.12.0
 Flask==1.1.2
 Flask-Compress==1.5.0
 future==0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ numpy==1.17.3
 nptyping
 packaging==19.2
 pandas
-plotly==4.7.1
+plotly==5.1.0
 pluggy==0.13.0
 py==1.10.0
 pyparsing==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ munch==2.5.0
 netCDF4==1.5.3
 numpy==1.17.3
 nptyping
+orjson==3.6.0
 packaging==19.2
 pandas
 plotly==5.1.0


### PR DESCRIPTION
With the intention of speeding up the heatmap data transfers: Upgrade Plotly and Dash; install `orjson`. Also remove the apparently unnecessary copying of the dv dataset.

According to [docs](https://plotly.com/python/renderers/#performance):

> If the orjson package is installed, plotly will use that instead of the built-in json package, which can lead to 5-10x speedups for large figures.

In order to ensure that `orjson` would in fact be used, I upgraded Plotly and Dash to the latest versions. This all works, but the result is a minor speedup of perhaps 10%, nothing of the order promised. Furthermore, of the data transfers observed, there is a large variation in times that must include quite a bit of dependency on externals such as network and file usage. It's not clear this made any difference at all, but it can't hurt.