### PR TITLE
Fix error in colorscale value targeting

### DIFF
--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -6,7 +6,7 @@ ui:
         # effects. This is not quite as abstract as would be nice, but it does
         # move the details of formatting from code to config.
         design-value-id:
-            value: RL50
+            value: HDD
             searchable: true
             clearable: false
         climate-regime:
@@ -67,7 +67,7 @@ ui:
         # Design variables to actually offer in the UI.
         # Simplifies commenting them in and out of service.
 #        - DRWP5
-#        - HDD
+        - HDD
 #        - IDFCF
 #        - MI
 #        - PAnn

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -281,7 +281,7 @@ def add(app, config):
             [
                 round_to_multiple(
                     data_value,
-                    dv_roundto(config, design_value_id, climate_regime) / 10,
+                    dv_roundto(config, design_value_id, climate_regime),
                 )
                 for data_value in tickvals
             ],

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -147,6 +147,7 @@ def add(app, config):
                 dv_units(config, design_value_id, climate_regime) == "ratio"
             )
             target = 1 if is_relative else 0
+            target = target if (zmin <= target <= zmax) else None
         boundaries = uniformly_spaced_with_target(
             zmin, zmax, num_colours + 1, target=target, scale=scale
         )

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -14,8 +14,12 @@ import numpy as np
 from dve.config import dv_has_climate_regime, dv_roundto, dv_units
 from dve.data import get_data
 from dve.colorbar import (
-    discrete_colorscale, colorscale_colors, discrete_colorscale_colorbar,
-    use_ticks, uniformly_spaced_with_target, scale_transform,
+    discrete_colorscale,
+    colorscale_colors,
+    discrete_colorscale_colorbar,
+    use_ticks,
+    uniformly_spaced_with_target,
+    scale_transform,
 )
 from dve.generate_iso_lines import lonlat_overlay
 from dve.config import dv_label, climate_regime_label, dataset_label
@@ -284,13 +288,7 @@ def add(app, config):
             colorscale,
             scale,
             tickvals,
-            [
-                round_to_multiple(
-                    t,
-                    roundto,
-                )
-                for t in tickvals
-            ],
+            [round_to_multiple(t, roundto) for t in tickvals],
         )
 
         return (


### PR DESCRIPTION
If the target value is not in the data range, don't use the target.

Also, miscellaneous:
- Don't use extra digit in colorbar annotations.
- Round zmin, zmax when viewing with linear scale. How to round for log scale is an open question, not done here.