### PR TITLE
Improve logarithmic colour scale

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -648,6 +648,7 @@ map:
             round_to: [1, 2, 3, 5, 10, 15]
             min: 40
             max: 85
+    logscale_zmin_factor: 100
 
 table_C2:
     cache_timeout: 0

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -648,6 +648,7 @@ map:
             round_to: [1, 2, 3, 5, 10, 15]
             min: 40
             max: 85
+    logscale_zmin_factor: 100
 
 table_C2:
     cache_timeout: 0

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -19,10 +19,9 @@ from dve.colorbar import (
     discrete_colorscale_colorbar,
     use_ticks,
     uniformly_spaced_with_target,
-    scale_transform,
 )
 from dve.generate_iso_lines import lonlat_overlay
-from dve.config import dv_label, climate_regime_label, dataset_label
+from dve.config import dv_label
 from dve.processing import coord_prep
 from dve.math_utils import round_to_multiple, sigfigs
 from dve.timing import timing

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -24,7 +24,7 @@ from dve.colorbar import (
 from dve.generate_iso_lines import lonlat_overlay
 from dve.config import dv_label, climate_regime_label, dataset_label
 from dve.processing import coord_prep
-from dve.math_utils import round_to_multiple, lon_0_to_360
+from dve.math_utils import round_to_multiple, sigfigs
 from dve.timing import timing
 
 from climpyrical.data import read_data
@@ -317,7 +317,9 @@ def add(app, config):
             colorscale,
             color_scale_type,
             tickvals,
-            [round_to_multiple(t, roundto) for t in tickvals],
+            # Formatting of tickvals is difficult; this seems to be a
+            # reasonable solution after several different experiments.
+            [sigfigs(t, 2) for t in tickvals],
         )
 
         return (

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -164,6 +164,13 @@ def add(app, config):
             )
             target = 1 if is_relative else 0
             target = target if (zmin <= target <= zmax) else None
+
+        # Hacky fix for logarithmic scales for data with min value zero.
+        # Note that log scale is prohibited for several datasets, but is allowed
+        # for a few (e.g., RL50) that can include 0.
+        if color_scale_type == "logarithmic" and zmin == 0:
+            zmin = zmax / config["map"]["logscale_zmin_factor"]
+
         boundaries = uniformly_spaced_with_target(
             zmin, zmax, num_colours + 1, target=target, scale=color_scale_type
         )

--- a/dve/colorbar.py
+++ b/dve/colorbar.py
@@ -6,6 +6,7 @@ import matplotlib.cm
 import plotly.graph_objects as go
 import numpy as np
 
+from dve.math_utils import nearest
 
 logger = logging.getLogger("dve")
 
@@ -233,3 +234,19 @@ def use_ticks(zmin, zmax, target, scale, num_colours, max_num_ticks):
     return uniformly_spaced_with_target(
         zmin, zmax, min(num_colours + 1, max_num_ticks), target, scale
     )
+
+
+def tick_roundto(tickvals):
+    num_ticks = len(tickvals)
+    tick_delta = (tickvals[-1] - tickvals[0]) / (num_ticks - 1)
+    tick_delta_pow_10 = 10 ** math.floor(math.log10(tick_delta))
+    tick_delta_mantissa = tick_delta / tick_delta_pow_10
+    nice_mantissa = nearest((1, 2, 5), tick_delta_mantissa)
+    roundto = nice_mantissa * tick_delta_pow_10
+    logger.debug(f"tick rounding: "
+                 f"num_ticks={num_ticks}, "
+                 f"tick_delta_pow_10={tick_delta_pow_10}, "
+                 f"tick_delta_mantissa={tick_delta_mantissa}, "
+                 f"nice_mantissa={nice_mantissa}, "
+                 f"tick_roundto={tick_roundto}, ")
+    return roundto


### PR DESCRIPTION
- Improve labelling (now using two sig figs, not rounding using rounding factors).
- Fix error when data min == 0. Use instead data max / factor; factor in config and presently = 100.