### PR TITLE
Use separate color mapping for future vs historical

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -434,7 +434,7 @@ dvs:
             colour_map: jet
             scale: linear
             colorbar:
-                sigfigs: 3
+                sigfigs: 4
         historical:
             datasets:
                 model: data/model_inputs/hurs_CanRCM4-LE_ens15_1951-2016_ensmean.nc

--- a/config.yml
+++ b/config.yml
@@ -187,7 +187,6 @@ dvs:
     DRWP5:
         description: Driving rain wind pressure, 1/5
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/driving_rain_wind_pressures_q5yr/D0.5C/DRWP5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/driving_rain_wind_pressures_q5yr/D1.0C/DRWP5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -196,12 +195,13 @@ dvs:
                 '2.5': data/change_factors/driving_rain_wind_pressures_q5yr/D2.0C/DRWP5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/drwp_CanRCM4-LE_ens15_1951-2016_rl5_ensmean.nc
                 reconstruction: data/reconstructions/DRWP5_reconstruction.nc
@@ -209,14 +209,15 @@ dvs:
                     column: DRWP-RL5 (Pa)
                     path: data/station_inputs/drwp_rl5_for_maps.csv
                 table_C2: data/tables/DRWP5_TableC2.csv
-            roundto: 10
-            scale:
-                default: linear
             units: kPa
+            roundto: 10
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     HDD:
         description: "Heating degree days above 18 \xB0C"
         future:
-            colour_map: RdBu
             datasets:
                 '0.5': data/change_factors/degree_days_below_18/D0.5C/HDD_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/degree_days_below_18/D1.0C/HDD_CanRCM4_ensmean_CF_DT1.0.nc
@@ -225,12 +226,13 @@ dvs:
                 '2.5': data/change_factors/degree_days_below_18/D2.0C/HDD_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC-day
+            roundto: 10
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 2
         historical:
-            colour_map: RdBu
             datasets:
                 model: data/model_inputs/hdd_CanRCM4-LE_ens35_1951-2016_ann_ensmean.nc
                 reconstruction: data/reconstructions/HDD_reconstruction.nc
@@ -238,14 +240,15 @@ dvs:
                     column: HDD (degC-day)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/HDD_TableC2.csv
-            roundto: 10
-            scale:
-                default: linear
             units: degC-day
+            roundto: 10
+            colour_map: RdBu
+            scale: linear
+            colorbar:
+                sigfigs: 3
     IDFCF:
         description: IDF future change factor
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -254,14 +257,15 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
     MI:
         description: Moisture index
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/foo/D0.5C/MI_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/foo/D1.0C/MI_CanRCM4_ensmean_CF_DT1.0.nc
@@ -270,12 +274,13 @@ dvs:
                 '2.5': data/change_factors/foo/D2.0C/MI_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: null
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/moisture_index_CanRCM4-LE_ens15_1951-2016_ensmean.nc
                 reconstruction: data/reconstructions/MI_reconstruction.nc
@@ -283,14 +288,15 @@ dvs:
                     column: moisture_index
                     path: data/station_inputs/moisture_index_for_maps.csv
                 table_C2: data/tables/MI_TableC2.csv
-            roundto: null
-            scale:
-                default: logarithmic
             units: ''
+            roundto: null
+            colour_map: terrain_r
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     PAnn:
         description: Annual total precipitation
         future:
-            colour_map: PuBuGn
             datasets:
                 '0.5': data/change_factors/annual_total_precipitation/D0.5C/PAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_total_precipitation/D1.0C/PAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -299,12 +305,13 @@ dvs:
                 '2.5': data/change_factors/annual_total_precipitation/D2.0C/PAnn_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/pr_CanRCM4-LE_ens35_1951-2016_ann_sum_ensmean.nc
                 reconstruction: data/reconstructions/PAnn_reconstruction.nc
@@ -312,14 +319,15 @@ dvs:
                     column: annual_pr (mm)
                     path: data/station_inputs/pr_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/PAnn_TableC2.csv
-            roundto: 5
-            scale:
-                default: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     R15m10:
         description: 15-min rainfall, 1/10
         future:
-            colour_map: PuBuGn
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -328,12 +336,13 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens15_1951-2016_max1hr_rl10_gum_lm_ensmean.nc
                 reconstruction: data/reconstructions/R15m10_reconstruction.nc
@@ -341,14 +350,15 @@ dvs:
                     column: Gum-LM RL10 (mm)
                     path: data/station_inputs/15min_rain_rl10_for_maps.csv
                 table_C2: data/tables/R15m10_TableC2.csv
-            roundto: 5
-            scale:
-                default: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     R1d50:
         description: 1-day rainfall, 1/50
         future:
-            colour_map: PuBuGn
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -357,12 +367,13 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens35_1951-2016_max1day_rl50_gum_lm_ensmean.nc
                 reconstruction: data/reconstructions/R1d50_reconstruction.nc
@@ -370,14 +381,15 @@ dvs:
                     column: 1day rain RL50 (mm)
                     path: data/station_inputs/1day_rain_rl50_for_maps.csv
                 table_C2: data/tables/R1d50_TableC2.csv
-            roundto: 1
-            scale:
-                default: logarithmic
             units: mm
+            roundto: 1
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     RAnn:
         description: Annual total rainfall
         future:
-            colour_map: PuBuGn
             datasets:
                 '0.5': data/change_factors/annual_rain/D0.5C/RAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_rain/D1.0C/RAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -386,12 +398,13 @@ dvs:
                 '2.5': data/change_factors/annual_rain/D2.0C/RAnn_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens35_1951-2016_ann_sum_ensmean.nc
                 reconstruction: data/reconstructions/RAnn_reconstruction.nc
@@ -399,14 +412,15 @@ dvs:
                     column: annual_rain (mm)
                     path: data/station_inputs/rain_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/RAnn_TableC2.csv
-            roundto: 5
-            scale:
-                default: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     RHann:
         description: Annual mean relative humidity
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/annual_relative_humidity/D0.5C/RHann_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_relative_humidity/D1.0C/RHann_CanRCM4_ensmean_CF_DT1.0.nc
@@ -415,12 +429,13 @@ dvs:
                 '2.5': data/change_factors/annual_relative_humidity/D2.0C/RHann_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/hurs_CanRCM4-LE_ens15_1951-2016_ensmean.nc
                 reconstruction: data/reconstructions/RHann_reconstruction.nc
@@ -428,14 +443,15 @@ dvs:
                     column: mean RH (%)
                     path: data/station_inputs/rh_annual_mean_10yr_for_maps.csv
                 table_C2: data/tables/RHann_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: '%'
+            roundto: 1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     RL50:
         description: Annual maximum rain-on-snow, 1/50
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/rain_q50yr/D0.5C/RL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/rain_q50yr/D1.0C/RL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -444,12 +460,13 @@ dvs:
                 '2.5': data/change_factors/rain_q50yr/D2.0C/RL50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: logarithmic
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/snw_rain_CanRCM4-LE_ens35_1951-2016_max_rl50_load_ensmean.nc
                 reconstruction: data/reconstructions/RL50_reconstruction.nc
@@ -457,14 +474,15 @@ dvs:
                     column: RL50 (kPa)
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/RL50_TableC2.csv
-            roundto: 0.1
-            scale:
-                default: logarithmic
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     SL50:
         description: Annual maximum snow load, 1/50
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/snow_q50yr/D0.5C/SL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/snow_q50yr/D1.0C/SL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -473,12 +491,13 @@ dvs:
                 '2.5': data/change_factors/snow_q50yr/D2.0C/SL50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/snw_CanRCM4-LE_ens35_1951-2016_max_rl50_load_ensmean.nc
                 reconstruction: data/reconstructions/SL50_reconstruction.nc
@@ -486,14 +505,15 @@ dvs:
                     column: SL50 (kPa)
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/SL50_TableC2.csv
-            roundto: 0.1
-            scale:
-                default: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJan1.0:
         description: January temperature 1%
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/january_1%_dry/D0.5C/TJan1.0_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_1%_dry/D1.0C/TJan1.0_CanRCM4_ensmean_CF_DT1.0.nc
@@ -502,12 +522,13 @@ dvs:
                 '2.5': data/change_factors/january_1%_dry/D2.0C/TJan1.0_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jan1.0p_ensmean.nc
                 reconstruction: data/reconstructions/TJan1.0_reconstruction.nc
@@ -515,14 +536,15 @@ dvs:
                     column: TJan1.0 (degC)
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan1.0_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJan2.5:
         description: January temperature 2.5%
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/january_2.5%_dry/D0.5C/TJan2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_2.5%_dry/D1.0C/TJan2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -531,12 +553,13 @@ dvs:
                 '2.5': data/change_factors/january_2.5%_dry/D2.0C/TJan2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jan2.5p_ensmean.nc
                 reconstruction: data/reconstructions/TJan2.5_reconstruction.nc
@@ -544,14 +567,15 @@ dvs:
                     column: TJan2.5 (degC)
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan2.5_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJul97.5:
         description: July temperature 97.5%
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/july_2.5%_dry/D0.5C/TJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_dry/D1.0C/TJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -560,12 +584,13 @@ dvs:
                 '2.5': data/change_factors/july_2.5%_dry/D2.0C/TJul2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jul97.5p_ensmean.nc
                 reconstruction: data/reconstructions/TJul97.5_reconstruction.nc
@@ -573,14 +598,15 @@ dvs:
                     column: TJul2.5 (degC)
                     path: data/station_inputs/julT97.5p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJul97.5_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     Tmax:
         description: Annual maximum daily temperature
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/maximum_mean_daily_temperature/D0.5C/Tmax_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/maximum_mean_daily_temperature/D1.0C/Tmax_CanRCM4_ensmean_CF_DT1.0.nc
@@ -589,12 +615,13 @@ dvs:
                 '2.5': data/change_factors/maximum_mean_daily_temperature/D2.0C/Tmax_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_ann_max_ensmean.nc
                 reconstruction: data/reconstructions/Tmax_reconstruction.nc
@@ -602,14 +629,15 @@ dvs:
                     column: Tmax (degC)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmax_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     Tmin:
         description: Annual minimum daily temperature
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/minimum_mean_daily_temperature/D0.5C/Tmin_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/minimum_mean_daily_temperature/D1.0C/Tmin_CanRCM4_ensmean_CF_DT1.0.nc
@@ -618,12 +646,13 @@ dvs:
                 '2.5': data/change_factors/minimum_mean_daily_temperature/D2.0C/Tmin_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_ann_min_ensmean.nc
                 reconstruction: data/reconstructions/Tmin_reconstruction.nc
@@ -631,14 +660,15 @@ dvs:
                     column: Tmin (degC)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmin_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TwJul97.5:
         description: July wet-bulb temperature 97.5%
         future:
-            colour_map: RdBu_r
             datasets:
                 '0.5': data/change_factors/july_2.5%_wet/D0.5C/TwJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_wet/D1.0C/TwJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -647,12 +677,13 @@ dvs:
                 '2.5': data/change_factors/july_2.5%_wet/D2.0C/TwJul2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/twb_CanRCM4-LE_ens35_1951-2016_1hr_jul97.5p_ensmean.nc
                 reconstruction: data/reconstructions/TwJul97.5_reconstruction.nc
@@ -660,14 +691,15 @@ dvs:
                     column: TwJul2.5 (degC)
                     path: data/station_inputs/julTwb97.5p_allstations_v3_for_maps.csv
                 table_C2: data/tables/TwJul97.5_TableC2.csv
-            roundto: 1
-            scale:
-                default: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     WP10:
         description: Annual maximum wind pressure, 1/10
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q10wp/D0.5C/WP10_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q10wp/D1.0C/WP10_CanRCM4_ensmean_CF_DT1.0.nc
@@ -676,12 +708,13 @@ dvs:
                 '2.5': data/change_factors/hourly_wind_pressures_q10wp/D2.0C/WP10_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/wpress_CanRCM4-LE_ens35_1951-2016_max_rl10_kpa_ensmean.nc
                 reconstruction: data/reconstructions/WP10_reconstruction.nc
@@ -689,14 +722,15 @@ dvs:
                     column: WP10 (kPa)
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP10_TableC2.csv
-            roundto: 0.1
-            scale:
-                default: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     WP50:
         description: Annual maximum wind pressure, 1/50
         future:
-            colour_map: terrain_r
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q50wp/D0.5C/WP50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q50wp/D1.0C/WP50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -705,12 +739,13 @@ dvs:
                 '2.5': data/change_factors/hourly_wind_pressures_q50wp/D2.0C/WP50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale:
-                default: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/wpress_CanRCM4-LE_ens35_1951-2016_max_rl50_kpa_ensmean.nc
                 reconstruction: data/reconstructions/WP50_reconstruction.nc
@@ -718,10 +753,13 @@ dvs:
                     column: WP50 (kPa)
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP50_TableC2.csv
-            roundto: 0.1
-            scale:
-                default: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
+
 
 map:
     colour_maps:

--- a/config.yml
+++ b/config.yml
@@ -258,19 +258,6 @@ dvs:
             scale:
                 default: linear
             units: ratio
-        historical:
-            colour_map: terrain_r
-            datasets:
-                model: null
-                reconstruction: null
-                stations:
-                    column: null
-                    path: null
-                table_C2: null
-            roundto: 0.001
-            scale:
-                default: linear
-            units: null
     MI:
         description: Moisture index
         future:

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -187,7 +187,7 @@ dvs:
     DRWP5:
         description: Driving rain wind pressure, 1/5
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/driving_rain_wind_pressures_q5yr/D0.5C/DRWP5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/driving_rain_wind_pressures_q5yr/D1.0C/DRWP5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -216,7 +216,7 @@ dvs:
     HDD:
         description: "Heating degree days above 18 \xB0C"
         future:
-            colour_map: RdBu
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/degree_days_below_18/D0.5C/HDD_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/degree_days_below_18/D1.0C/HDD_CanRCM4_ensmean_CF_DT1.0.nc
@@ -245,7 +245,7 @@ dvs:
     IDFCF:
         description: IDF future change factor
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -261,7 +261,7 @@ dvs:
     MI:
         description: Moisture index
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/foo/D0.5C/MI_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/foo/D1.0C/MI_CanRCM4_ensmean_CF_DT1.0.nc
@@ -272,7 +272,7 @@ dvs:
                 '3.5': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: null
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -290,7 +290,7 @@ dvs:
     PAnn:
         description: Annual total precipitation
         future:
-            colour_map: PuBuGn
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_total_precipitation/D0.5C/PAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_total_precipitation/D1.0C/PAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -301,7 +301,7 @@ dvs:
                 '3.5': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -319,7 +319,7 @@ dvs:
     R15m10:
         description: 15-min rainfall, 1/10
         future:
-            colour_map: PuBuGn
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -330,7 +330,7 @@ dvs:
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
             roundto: 0.001
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -348,7 +348,7 @@ dvs:
     R1d50:
         description: 1-day rainfall, 1/50
         future:
-            colour_map: PuBuGn
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -359,7 +359,7 @@ dvs:
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
             roundto: 0.001
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -377,7 +377,7 @@ dvs:
     RAnn:
         description: Annual total rainfall
         future:
-            colour_map: PuBuGn
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_rain/D0.5C/RAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_rain/D1.0C/RAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -388,7 +388,7 @@ dvs:
                 '3.5': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -406,7 +406,7 @@ dvs:
     RHann:
         description: Annual mean relative humidity
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_relative_humidity/D0.5C/RHann_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_relative_humidity/D1.0C/RHann_CanRCM4_ensmean_CF_DT1.0.nc
@@ -435,7 +435,7 @@ dvs:
     RL50:
         description: Annual maximum rain-on-snow, 1/50
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/rain_q50yr/D0.5C/RL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/rain_q50yr/D1.0C/RL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -446,7 +446,7 @@ dvs:
                 '3.5': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
             scale:
-                default: logarithmic
+                default: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -464,7 +464,7 @@ dvs:
     SL50:
         description: Annual maximum snow load, 1/50
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/snow_q50yr/D0.5C/SL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/snow_q50yr/D1.0C/SL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -493,7 +493,7 @@ dvs:
     TJan1.0:
         description: January temperature 1%
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/january_1%_dry/D0.5C/TJan1.0_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_1%_dry/D1.0C/TJan1.0_CanRCM4_ensmean_CF_DT1.0.nc
@@ -522,7 +522,7 @@ dvs:
     TJan2.5:
         description: January temperature 2.5%
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/january_2.5%_dry/D0.5C/TJan2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_2.5%_dry/D1.0C/TJan2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -551,7 +551,7 @@ dvs:
     TJul97.5:
         description: July temperature 97.5%
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/july_2.5%_dry/D0.5C/TJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_dry/D1.0C/TJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -580,7 +580,7 @@ dvs:
     Tmax:
         description: Annual maximum daily temperature
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/maximum_mean_daily_temperature/D0.5C/Tmax_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/maximum_mean_daily_temperature/D1.0C/Tmax_CanRCM4_ensmean_CF_DT1.0.nc
@@ -609,7 +609,7 @@ dvs:
     Tmin:
         description: Annual minimum daily temperature
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/minimum_mean_daily_temperature/D0.5C/Tmin_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/minimum_mean_daily_temperature/D1.0C/Tmin_CanRCM4_ensmean_CF_DT1.0.nc
@@ -638,7 +638,7 @@ dvs:
     TwJul97.5:
         description: July wet-bulb temperature 97.5%
         future:
-            colour_map: RdBu_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/july_2.5%_wet/D0.5C/TwJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_wet/D1.0C/TwJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -667,7 +667,7 @@ dvs:
     WP10:
         description: Annual maximum wind pressure, 1/10
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q10wp/D0.5C/WP10_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q10wp/D1.0C/WP10_CanRCM4_ensmean_CF_DT1.0.nc
@@ -696,7 +696,7 @@ dvs:
     WP50:
         description: Annual maximum wind pressure, 1/50
         future:
-            colour_map: terrain_r
+            colour_map: jet
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q50wp/D0.5C/WP50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q50wp/D1.0C/WP50_CanRCM4_ensmean_CF_DT1.0.nc

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -434,7 +434,7 @@ dvs:
             colour_map: jet
             scale: linear
             colorbar:
-                sigfigs: 3
+                sigfigs: 4
         historical:
             datasets:
                 model: data/model_inputs/hurs_CanRCM4-LE_ens15_1951-2016_ensmean.nc

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -227,11 +227,11 @@ dvs:
                 '3.0': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC-day
-            roundto: 0.001
+            roundto: 10
             colour_map: jet
             scale: linear
             colorbar:
-                sigfigs: 3
+                sigfigs: 2
         historical:
             datasets:
                 model: data/model_inputs/hdd_CanRCM4-LE_ens35_1951-2016_ann_ensmean.nc
@@ -275,7 +275,7 @@ dvs:
                 '3.0': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
             units: ratio
-            roundto: null
+            roundto: 0.001
             colour_map: jet
             scale: linear
             colorbar:
@@ -523,7 +523,7 @@ dvs:
                 '3.0': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:
@@ -554,7 +554,7 @@ dvs:
                 '3.0': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:
@@ -585,7 +585,7 @@ dvs:
                 '3.0': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:
@@ -616,7 +616,7 @@ dvs:
                 '3.0': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:
@@ -647,7 +647,7 @@ dvs:
                 '3.0': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:
@@ -678,7 +678,7 @@ dvs:
                 '3.0': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
             units: degC
-            roundto: 0.001
+            roundto: 1
             colour_map: jet
             scale: linear
             colorbar:

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -258,19 +258,6 @@ dvs:
             scale:
                 default: linear
             units: ratio
-        historical:
-            colour_map: terrain_r
-            datasets:
-                model: null
-                reconstruction: null
-                stations:
-                    column: null
-                    path: null
-                table_C2: null
-            roundto: 0.001
-            scale:
-                default: linear
-            units: null
     MI:
         description: Moisture index
         future:

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -187,7 +187,6 @@ dvs:
     DRWP5:
         description: Driving rain wind pressure, 1/5
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/driving_rain_wind_pressures_q5yr/D0.5C/DRWP5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/driving_rain_wind_pressures_q5yr/D1.0C/DRWP5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -196,11 +195,13 @@ dvs:
                 '2.5': data/change_factors/driving_rain_wind_pressures_q5yr/D2.0C/DRWP5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/drwp_CanRCM4-LE_ens15_1951-2016_rl5_ensmean.nc
                 reconstruction: data/reconstructions/DRWP5_reconstruction.nc
@@ -208,13 +209,15 @@ dvs:
                     column: DRWP-RL5 (Pa)
                     path: data/station_inputs/drwp_rl5_for_maps.csv
                 table_C2: data/tables/DRWP5_TableC2.csv
-            roundto: 10
-            scale: linear
             units: kPa
+            roundto: 10
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     HDD:
         description: "Heating degree days above 18 \xB0C"
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/degree_days_below_18/D0.5C/HDD_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/degree_days_below_18/D1.0C/HDD_CanRCM4_ensmean_CF_DT1.0.nc
@@ -223,11 +226,13 @@ dvs:
                 '2.5': data/change_factors/degree_days_below_18/D2.0C/HDD_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC-day
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu
             datasets:
                 model: data/model_inputs/hdd_CanRCM4-LE_ens35_1951-2016_ann_ensmean.nc
                 reconstruction: data/reconstructions/HDD_reconstruction.nc
@@ -235,13 +240,15 @@ dvs:
                     column: HDD (degC-day)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/HDD_TableC2.csv
-            roundto: 10
-            scale: linear
             units: degC-day
+            roundto: 10
+            colour_map: RdBu
+            scale: linear
+            colorbar:
+                sigfigs: 3
     IDFCF:
         description: IDF future change factor
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -250,13 +257,15 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
     MI:
         description: Moisture index
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/foo/D0.5C/MI_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/foo/D1.0C/MI_CanRCM4_ensmean_CF_DT1.0.nc
@@ -265,11 +274,13 @@ dvs:
                 '2.5': data/change_factors/foo/D2.0C/MI_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: null
-            scale: linear
             units: ratio
+            roundto: null
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/moisture_index_CanRCM4-LE_ens15_1951-2016_ensmean.nc
                 reconstruction: data/reconstructions/MI_reconstruction.nc
@@ -277,13 +288,15 @@ dvs:
                     column: moisture_index
                     path: data/station_inputs/moisture_index_for_maps.csv
                 table_C2: data/tables/MI_TableC2.csv
-            roundto: null
-            scale: logarithmic
             units: ''
+            roundto: null
+            colour_map: terrain_r
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     PAnn:
         description: Annual total precipitation
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_total_precipitation/D0.5C/PAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_total_precipitation/D1.0C/PAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -292,11 +305,13 @@ dvs:
                 '2.5': data/change_factors/annual_total_precipitation/D2.0C/PAnn_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/pr_CanRCM4-LE_ens35_1951-2016_ann_sum_ensmean.nc
                 reconstruction: data/reconstructions/PAnn_reconstruction.nc
@@ -304,13 +319,15 @@ dvs:
                     column: annual_pr (mm)
                     path: data/station_inputs/pr_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/PAnn_TableC2.csv
-            roundto: 5
-            scale: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     R15m10:
         description: 15-min rainfall, 1/10
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -319,11 +336,13 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens15_1951-2016_max1hr_rl10_gum_lm_ensmean.nc
                 reconstruction: data/reconstructions/R15m10_reconstruction.nc
@@ -331,13 +350,15 @@ dvs:
                     column: Gum-LM RL10 (mm)
                     path: data/station_inputs/15min_rain_rl10_for_maps.csv
                 table_C2: data/tables/R15m10_TableC2.csv
-            roundto: 5
-            scale: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     R1d50:
         description: 1-day rainfall, 1/50
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2016_DT0.5_Reconstruction.nc
                 '1.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2028_DT1.0_Reconstruction.nc
@@ -346,11 +367,13 @@ dvs:
                 '2.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2059_DT2.5_Reconstruction.nc
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens35_1951-2016_max1day_rl50_gum_lm_ensmean.nc
                 reconstruction: data/reconstructions/R1d50_reconstruction.nc
@@ -358,13 +381,15 @@ dvs:
                     column: 1day rain RL50 (mm)
                     path: data/station_inputs/1day_rain_rl50_for_maps.csv
                 table_C2: data/tables/R1d50_TableC2.csv
-            roundto: 1
-            scale: logarithmic
             units: mm
+            roundto: 1
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     RAnn:
         description: Annual total rainfall
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_rain/D0.5C/RAnn_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_rain/D1.0C/RAnn_CanRCM4_ensmean_CF_DT1.0.nc
@@ -373,11 +398,13 @@ dvs:
                 '2.5': data/change_factors/annual_rain/D2.0C/RAnn_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: PuBuGn
             datasets:
                 model: data/model_inputs/rain_CanRCM4-LE_ens35_1951-2016_ann_sum_ensmean.nc
                 reconstruction: data/reconstructions/RAnn_reconstruction.nc
@@ -385,13 +412,15 @@ dvs:
                     column: annual_rain (mm)
                     path: data/station_inputs/rain_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/RAnn_TableC2.csv
-            roundto: 5
-            scale: logarithmic
             units: mm
+            roundto: 5
+            colour_map: PuBuGn
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     RHann:
         description: Annual mean relative humidity
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/annual_relative_humidity/D0.5C/RHann_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/annual_relative_humidity/D1.0C/RHann_CanRCM4_ensmean_CF_DT1.0.nc
@@ -400,11 +429,13 @@ dvs:
                 '2.5': data/change_factors/annual_relative_humidity/D2.0C/RHann_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/hurs_CanRCM4-LE_ens15_1951-2016_ensmean.nc
                 reconstruction: data/reconstructions/RHann_reconstruction.nc
@@ -412,13 +443,15 @@ dvs:
                     column: mean RH (%)
                     path: data/station_inputs/rh_annual_mean_10yr_for_maps.csv
                 table_C2: data/tables/RHann_TableC2.csv
-            roundto: 1
-            scale: linear
             units: '%'
+            roundto: 1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     RL50:
         description: Annual maximum rain-on-snow, 1/50
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/rain_q50yr/D0.5C/RL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/rain_q50yr/D1.0C/RL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -427,11 +460,13 @@ dvs:
                 '2.5': data/change_factors/rain_q50yr/D2.0C/RL50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/snw_rain_CanRCM4-LE_ens35_1951-2016_max_rl50_load_ensmean.nc
                 reconstruction: data/reconstructions/RL50_reconstruction.nc
@@ -439,13 +474,15 @@ dvs:
                     column: RL50 (kPa)
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/RL50_TableC2.csv
-            roundto: 0.1
-            scale: logarithmic
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: logarithmic
+            colorbar:
+                sigfigs: 3
     SL50:
         description: Annual maximum snow load, 1/50
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/snow_q50yr/D0.5C/SL50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/snow_q50yr/D1.0C/SL50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -454,11 +491,13 @@ dvs:
                 '2.5': data/change_factors/snow_q50yr/D2.0C/SL50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/snw_CanRCM4-LE_ens35_1951-2016_max_rl50_load_ensmean.nc
                 reconstruction: data/reconstructions/SL50_reconstruction.nc
@@ -466,13 +505,15 @@ dvs:
                     column: SL50 (kPa)
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/SL50_TableC2.csv
-            roundto: 0.1
-            scale: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJan1.0:
         description: January temperature 1%
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/january_1%_dry/D0.5C/TJan1.0_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_1%_dry/D1.0C/TJan1.0_CanRCM4_ensmean_CF_DT1.0.nc
@@ -481,11 +522,13 @@ dvs:
                 '2.5': data/change_factors/january_1%_dry/D2.0C/TJan1.0_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jan1.0p_ensmean.nc
                 reconstruction: data/reconstructions/TJan1.0_reconstruction.nc
@@ -493,13 +536,15 @@ dvs:
                     column: TJan1.0 (degC)
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan1.0_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJan2.5:
         description: January temperature 2.5%
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/january_2.5%_dry/D0.5C/TJan2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/january_2.5%_dry/D1.0C/TJan2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -508,11 +553,13 @@ dvs:
                 '2.5': data/change_factors/january_2.5%_dry/D2.0C/TJan2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jan2.5p_ensmean.nc
                 reconstruction: data/reconstructions/TJan2.5_reconstruction.nc
@@ -520,13 +567,15 @@ dvs:
                     column: TJan2.5 (degC)
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan2.5_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TJul97.5:
         description: July temperature 97.5%
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/july_2.5%_dry/D0.5C/TJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_dry/D1.0C/TJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -535,11 +584,13 @@ dvs:
                 '2.5': data/change_factors/july_2.5%_dry/D2.0C/TJul2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_1hr_jul97.5p_ensmean.nc
                 reconstruction: data/reconstructions/TJul97.5_reconstruction.nc
@@ -547,13 +598,15 @@ dvs:
                     column: TJul2.5 (degC)
                     path: data/station_inputs/julT97.5p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJul97.5_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     Tmax:
         description: Annual maximum daily temperature
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/maximum_mean_daily_temperature/D0.5C/Tmax_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/maximum_mean_daily_temperature/D1.0C/Tmax_CanRCM4_ensmean_CF_DT1.0.nc
@@ -562,11 +615,13 @@ dvs:
                 '2.5': data/change_factors/maximum_mean_daily_temperature/D2.0C/Tmax_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_ann_max_ensmean.nc
                 reconstruction: data/reconstructions/Tmax_reconstruction.nc
@@ -574,13 +629,15 @@ dvs:
                     column: Tmax (degC)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmax_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     Tmin:
         description: Annual minimum daily temperature
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/minimum_mean_daily_temperature/D0.5C/Tmin_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/minimum_mean_daily_temperature/D1.0C/Tmin_CanRCM4_ensmean_CF_DT1.0.nc
@@ -589,11 +646,13 @@ dvs:
                 '2.5': data/change_factors/minimum_mean_daily_temperature/D2.0C/Tmin_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/tas_CanRCM4-LE_ens35_1951-2016_ann_min_ensmean.nc
                 reconstruction: data/reconstructions/Tmin_reconstruction.nc
@@ -601,13 +660,15 @@ dvs:
                     column: Tmin (degC)
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmin_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     TwJul97.5:
         description: July wet-bulb temperature 97.5%
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/july_2.5%_wet/D0.5C/TwJul2.5_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/july_2.5%_wet/D1.0C/TwJul2.5_CanRCM4_ensmean_CF_DT1.0.nc
@@ -616,11 +677,13 @@ dvs:
                 '2.5': data/change_factors/july_2.5%_wet/D2.0C/TwJul2.5_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: degC
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: RdBu_r
             datasets:
                 model: data/model_inputs/twb_CanRCM4-LE_ens35_1951-2016_1hr_jul97.5p_ensmean.nc
                 reconstruction: data/reconstructions/TwJul97.5_reconstruction.nc
@@ -628,13 +691,15 @@ dvs:
                     column: TwJul2.5 (degC)
                     path: data/station_inputs/julTwb97.5p_allstations_v3_for_maps.csv
                 table_C2: data/tables/TwJul97.5_TableC2.csv
-            roundto: 1
-            scale: linear
             units: degC
+            roundto: 1
+            colour_map: RdBu_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     WP10:
         description: Annual maximum wind pressure, 1/10
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q10wp/D0.5C/WP10_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q10wp/D1.0C/WP10_CanRCM4_ensmean_CF_DT1.0.nc
@@ -643,11 +708,13 @@ dvs:
                 '2.5': data/change_factors/hourly_wind_pressures_q10wp/D2.0C/WP10_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/wpress_CanRCM4-LE_ens35_1951-2016_max_rl10_kpa_ensmean.nc
                 reconstruction: data/reconstructions/WP10_reconstruction.nc
@@ -655,13 +722,15 @@ dvs:
                     column: WP10 (kPa)
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP10_TableC2.csv
-            roundto: 0.1
-            scale: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
     WP50:
         description: Annual maximum wind pressure, 1/50
         future:
-            colour_map: jet
             datasets:
                 '0.5': data/change_factors/hourly_wind_pressures_q50wp/D0.5C/WP50_CanRCM4_ensmean_CF_DT0.5.nc
                 '1.0': data/change_factors/hourly_wind_pressures_q50wp/D1.0C/WP50_CanRCM4_ensmean_CF_DT1.0.nc
@@ -670,11 +739,13 @@ dvs:
                 '2.5': data/change_factors/hourly_wind_pressures_q50wp/D2.0C/WP50_CanRCM4_ensmean_CF_DT2.0.nc
                 '3.0': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
-            roundto: 0.001
-            scale: linear
             units: ratio
+            roundto: 0.001
+            colour_map: jet
+            scale: linear
+            colorbar:
+                sigfigs: 3
         historical:
-            colour_map: terrain_r
             datasets:
                 model: data/model_inputs/wpress_CanRCM4-LE_ens35_1951-2016_max_rl50_kpa_ensmean.nc
                 reconstruction: data/reconstructions/WP50_reconstruction.nc
@@ -682,9 +753,12 @@ dvs:
                     column: WP50 (kPa)
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP50_TableC2.csv
-            roundto: 0.1
-            scale: linear
             units: kPa
+            roundto: 0.1
+            colour_map: terrain_r
+            scale: linear
+            colorbar:
+                sigfigs: 3
 
 
 map:

--- a/docker/dev-local/config.yml
+++ b/docker/dev-local/config.yml
@@ -197,8 +197,7 @@ dvs:
                 '3.0': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/driving_rain_wind_pressures_q5yr/D3.0C/DRWP5_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -210,8 +209,7 @@ dvs:
                     path: data/station_inputs/drwp_rl5_for_maps.csv
                 table_C2: data/tables/DRWP5_TableC2.csv
             roundto: 10
-            scale:
-                default: linear
+            scale: linear
             units: kPa
     HDD:
         description: "Heating degree days above 18 \xB0C"
@@ -226,8 +224,7 @@ dvs:
                 '3.0': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/degree_days_below_18/D3.0C/HDD_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC-day
         historical:
             colour_map: RdBu
@@ -239,8 +236,7 @@ dvs:
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/HDD_TableC2.csv
             roundto: 10
-            scale:
-                default: linear
+            scale: linear
             units: degC-day
     IDFCF:
         description: IDF future change factor
@@ -255,8 +251,7 @@ dvs:
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
     MI:
         description: Moisture index
@@ -271,8 +266,7 @@ dvs:
                 '3.0': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/foo/D3.0C/MI_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: null
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -284,8 +278,7 @@ dvs:
                     path: data/station_inputs/moisture_index_for_maps.csv
                 table_C2: data/tables/MI_TableC2.csv
             roundto: null
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: ''
     PAnn:
         description: Annual total precipitation
@@ -300,8 +293,7 @@ dvs:
                 '3.0': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_total_precipitation/D3.0C/PAnn_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -313,8 +305,7 @@ dvs:
                     path: data/station_inputs/pr_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/PAnn_TableC2.csv
             roundto: 5
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: mm
     R15m10:
         description: 15-min rainfall, 1/10
@@ -329,8 +320,7 @@ dvs:
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -342,8 +332,7 @@ dvs:
                     path: data/station_inputs/15min_rain_rl10_for_maps.csv
                 table_C2: data/tables/R15m10_TableC2.csv
             roundto: 5
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: mm
     R1d50:
         description: 1-day rainfall, 1/50
@@ -358,8 +347,7 @@ dvs:
                 '3.0': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2068_DT3.0_Reconstruction.nc
                 '3.5': data/change_factors/IDF_scale_factors/scalef_CanRCM4-LE_2077_DT3.5_Reconstruction.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -371,8 +359,7 @@ dvs:
                     path: data/station_inputs/1day_rain_rl50_for_maps.csv
                 table_C2: data/tables/R1d50_TableC2.csv
             roundto: 1
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: mm
     RAnn:
         description: Annual total rainfall
@@ -387,8 +374,7 @@ dvs:
                 '3.0': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_rain/D3.0C/RAnn_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: PuBuGn
@@ -400,8 +386,7 @@ dvs:
                     path: data/station_inputs/rain_annual_mean_doy_MSC_25yr_for_maps.csv
                 table_C2: data/tables/RAnn_TableC2.csv
             roundto: 5
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: mm
     RHann:
         description: Annual mean relative humidity
@@ -416,8 +401,7 @@ dvs:
                 '3.0': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/annual_relative_humidity/D3.0C/RHann_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -429,8 +413,7 @@ dvs:
                     path: data/station_inputs/rh_annual_mean_10yr_for_maps.csv
                 table_C2: data/tables/RHann_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: '%'
     RL50:
         description: Annual maximum rain-on-snow, 1/50
@@ -445,8 +428,7 @@ dvs:
                 '3.0': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/rain_q50yr/D3.0C/RL50_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -458,8 +440,7 @@ dvs:
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/RL50_TableC2.csv
             roundto: 0.1
-            scale:
-                default: logarithmic
+            scale: logarithmic
             units: kPa
     SL50:
         description: Annual maximum snow load, 1/50
@@ -474,8 +455,7 @@ dvs:
                 '3.0': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/snow_q50yr/D3.0C/SL50_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -487,8 +467,7 @@ dvs:
                     path: data/station_inputs/sl50_rl50_for_maps.csv
                 table_C2: data/tables/SL50_TableC2.csv
             roundto: 0.1
-            scale:
-                default: linear
+            scale: linear
             units: kPa
     TJan1.0:
         description: January temperature 1%
@@ -503,8 +482,7 @@ dvs:
                 '3.0': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_1%_dry/D3.0C/TJan1.0_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -516,8 +494,7 @@ dvs:
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan1.0_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     TJan2.5:
         description: January temperature 2.5%
@@ -532,8 +509,7 @@ dvs:
                 '3.0': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/january_2.5%_dry/D3.0C/TJan2.5_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -545,8 +521,7 @@ dvs:
                     path: data/station_inputs/janT2.5p_T1.0p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJan2.5_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     TJul97.5:
         description: July temperature 97.5%
@@ -561,8 +536,7 @@ dvs:
                 '3.0': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_dry/D3.0C/TJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -574,8 +548,7 @@ dvs:
                     path: data/station_inputs/julT97.5p_allstations_v3_min8yr_for_maps.csv
                 table_C2: data/tables/TJul97.5_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     Tmax:
         description: Annual maximum daily temperature
@@ -590,8 +563,7 @@ dvs:
                 '3.0': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/maximum_mean_daily_temperature/D3.0C/Tmax_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -603,8 +575,7 @@ dvs:
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmax_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     Tmin:
         description: Annual minimum daily temperature
@@ -619,8 +590,7 @@ dvs:
                 '3.0': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/minimum_mean_daily_temperature/D3.0C/Tmin_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -632,8 +602,7 @@ dvs:
                     path: data/station_inputs/hdd_Tmax_Tmin_allstations_v3_for_maps.csv
                 table_C2: data/tables/Tmin_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     TwJul97.5:
         description: July wet-bulb temperature 97.5%
@@ -648,8 +617,7 @@ dvs:
                 '3.0': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/july_2.5%_wet/D3.0C/TwJul2.5_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: degC
         historical:
             colour_map: RdBu_r
@@ -661,8 +629,7 @@ dvs:
                     path: data/station_inputs/julTwb97.5p_allstations_v3_for_maps.csv
                 table_C2: data/tables/TwJul97.5_TableC2.csv
             roundto: 1
-            scale:
-                default: linear
+            scale: linear
             units: degC
     WP10:
         description: Annual maximum wind pressure, 1/10
@@ -677,8 +644,7 @@ dvs:
                 '3.0': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q10wp/D3.0C/WP10_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -690,8 +656,7 @@ dvs:
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP10_TableC2.csv
             roundto: 0.1
-            scale:
-                default: linear
+            scale: linear
             units: kPa
     WP50:
         description: Annual maximum wind pressure, 1/50
@@ -706,8 +671,7 @@ dvs:
                 '3.0': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
                 '3.5': data/change_factors/hourly_wind_pressures_q50wp/D3.0C/WP50_CanRCM4_ensmean_CF_DT3.0.nc
             roundto: 0.001
-            scale:
-                default: linear
+            scale: linear
             units: ratio
         historical:
             colour_map: terrain_r
@@ -719,8 +683,7 @@ dvs:
                     path: data/station_inputs/wpress_stations_rl10_rl50_for_maps.csv
                 table_C2: data/tables/WP50_TableC2.csv
             roundto: 0.1
-            scale:
-                default: linear
+            scale: linear
             units: kPa
 
 

--- a/dve/callbacks/colour_scale.py
+++ b/dve/callbacks/colour_scale.py
@@ -9,7 +9,7 @@ from dve.config import (
     dv_has_climate_regime,
     dv_roundto,
     dv_colour_map,
-    dv_colour_scale_type_default,
+    dv_colour_scale_type,
 )
 from dve.data import get_data
 import dve.layout
@@ -31,7 +31,7 @@ def add(app, config):
         [Input("design_variable", "value"), Input("climate_regime", "value")],
     )
     def update_colour_scale_type(design_variable, climate_regime):
-        return dv_colour_scale_type_default(
+        return dv_colour_scale_type(
             config, design_variable, climate_regime
         )
 

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -12,8 +12,12 @@ import geopandas as gpd
 import numpy as np
 
 from dve.config import (
-    dv_has_climate_regime, dv_roundto, dv_units, map_title,
+    dv_has_climate_regime,
+    dv_roundto,
+    dv_units,
+    map_title,
     dv_historical_stations_column,
+    dv_colour_bar_sigfigs,
 )
 from dve.data import get_data
 from dve.colorbar import (
@@ -285,7 +289,9 @@ def add(app, config):
                 "historical",
                 historical_dataset_id="stations",
             ).data_frame()
-            stations_column = dv_historical_stations_column(config, design_variable)
+            stations_column = dv_historical_stations_column(
+                config, design_variable
+            )
             with timing("coord_prep for stations", log=timing_log):
                 df = coord_prep(df, stations_column)
             figures.append(
@@ -327,9 +333,15 @@ def add(app, config):
             colorscale,
             color_scale_type,
             tickvals,
-            # Formatting of tickvals is difficult; this seems to be a
-            # reasonable solution after several different experiments.
-            [sigfigs(t, 3) for t in tickvals],
+            [
+                sigfigs(
+                    t,
+                    dv_colour_bar_sigfigs(
+                        config, design_variable, climate_regime
+                    ),
+                )
+                for t in tickvals
+            ],
         )
 
         return (

--- a/dve/config.py
+++ b/dve/config.py
@@ -148,8 +148,8 @@ def dv_colour_map(config, design_variable, climate_regime):
     return config["dvs"][design_variable][climate_regime]["colour_map"]
 
 
-def dv_colour_scale_type_default(config, design_variable, climate_regime):
-    return config["dvs"][design_variable][climate_regime]["scale"]["default"]
+def dv_colour_scale_type(config, design_variable, climate_regime):
+    return config["dvs"][design_variable][climate_regime]["scale"]
 
 
 def dv_historical_stations_column(config, design_variable):

--- a/dve/config.py
+++ b/dve/config.py
@@ -152,6 +152,10 @@ def dv_colour_scale_type(config, design_variable, climate_regime):
     return config["dvs"][design_variable][climate_regime]["scale"]
 
 
+def dv_colour_bar_sigfigs(config, design_variable, climate_regime):
+    return config["dvs"][design_variable][climate_regime]["colorbar"]["sigfigs"]
+
+
 def dv_historical_stations_column(config, design_variable):
     return config["dvs"][design_variable]["historical"]["stations"]["column"]
 


### PR DESCRIPTION
Following refactoring of config, use it to present future datasets differently than historical.

Resolves #93 