### PR TITLE
Fix double updates

### DIFF
--- a/config/local_preferences.yml
+++ b/config/local_preferences.yml
@@ -1,6 +1,8 @@
+# For documentation of this config, see dve/callbacks/local_preferences.py
+
 version: 16
 path_separator: ";"
-function_prefix: "@"
+function_marker: "@"
 ui_elements:
   - selector: main_tabs.active_tab
     paths:

--- a/config/local_preferences.yml
+++ b/config/local_preferences.yml
@@ -2,29 +2,47 @@ version: 16
 path_separator: ";"
 function_prefix: "@"
 ui_elements:
-  - id: main_tabs
-    prop: active_tab
-    global: ui;controls;main_tabs;active_tab
-  - id: help_tabs
-    prop: active_tab
-    global: ui;controls;help_tabs;active_tab
-  - id: about_tabs
-    prop: active_tab
-    global: ui;controls;about_tabs;active_tab
-  - id: show_stations
-    prop: "on"
-    global: "@show_stations"
-    local: ui;controls;stations;{climate_regime};on
-  - id: show_grid
-    prop: "on"
-    global: ui;controls;grid;on
-  - id: num_colors
-    prop: value
-    global: ui;controls;num-colours;value
-    local: dvs;{design_variable};{climate_regime};num_colours
-  - id: color_map
-    prop: value
-    global: dvs;{design_variable};{climate_regime};colour_map
-  - id: color_scale_type
-    prop: value
-    global: dvs;{design_variable};{climate_regime};scale;default
+  - selector: main_tabs.active_tab
+    paths:
+      global: ui;controls;main_tabs;active_tab
+
+  - selector: help_tabs.active_tab
+    paths:
+      global: ui;controls;help_tabs;active_tab
+
+  - selector: about_tabs.active_tab
+    paths:
+      global: ui;controls;about_tabs;active_tab
+
+  - selector: show_stations.on
+    inputs:
+      climate_regime: climate_regime.value
+    paths:
+      global: "@show_stations"
+      local: ui;controls;stations;{climate_regime};on
+
+  - selector: show_grid.on
+    paths:
+      global: ui;controls;grid;on
+
+  - selector: num_colors.value
+    inputs:
+      design_variable: design_variable.value
+      climate_regime: climate_regime.value
+    paths:
+      global: ui;controls;num-colours;value
+      local: dvs;{design_variable};{climate_regime};num_colours
+
+  - selector: color_map.value
+    inputs:
+      design_variable: design_variable.value
+      climate_regime: climate_regime.value
+    paths:
+      global: dvs;{design_variable};{climate_regime};colour_map
+
+  - selector: color_scale_type.value
+    inputs:
+      design_variable: design_variable.value
+      climate_regime: climate_regime.value
+    paths:
+      global: dvs;{design_variable};{climate_regime};scale;default

--- a/config/local_preferences.yml
+++ b/config/local_preferences.yml
@@ -1,9 +1,15 @@
 # For documentation of this config, see dve/callbacks/local_preferences.py
 
-version: 16
+version: 17
 path_separator: ";"
 function_marker: "@"
 ui_elements:
+  # Adding this local pref causes the double-update problem to occur.
+  # This is diagnostic, of course, but no time to pursue it. TODO.
+  # - selector: design_variable.value
+  #    paths:
+  #      global: ui;controls;design-value-id;value
+
   - selector: main_tabs.active_tab
     paths:
       global: ui;controls;main_tabs;active_tab


### PR DESCRIPTION
Resolves #205 

... mostly. There is still a double update on transition from Map to Table tab. Grrr.

A side benefit of this fix is that the local preferences mechanism is both more flexible and targets local-pref item inputs  specifically rather than generically. A nice improvement.