### PR TITLE
Update documentation; improve behaviour on no data

### DIFF
--- a/config/about.yml
+++ b/config/about.yml
@@ -3,18 +3,59 @@ tabs:
     cards:
       - header: Description
         body: |
-          Design Value Explorer presents maps and tables giving values for
-          design variables at locations across Canada based on historical and
-          projected future climate.
+          Design Value Explorer provides revised climatic design data relevant 
+          to the National Building Code of Canada (NBCC 2015, Table C-2) and 
+          the Canadian Highway Bridge Design Code (CHBDC/ CSA S6 2014, 
+          Annex A3.1) that has not yet been reviewed and accepted for 
+          inclusion into updates to these codes, and thus should only be 
+          considered as advisory information. Design decisions should always 
+          be made following the appropriate codes and standards. It is 
+          important to note that it remains the responsibility of the users 
+          of these climatic data to determine whether it is suitable for their 
+          particular purpose. In many instances, new methods were developed 
+          to quality control the underlying raw data and also to make the 
+          best use of these data to calculate design values. State-of-the-art 
+          regional climate model simulations were used both to aid in the 
+          interpolation of historical design values, and also to derive 
+          future changes in these elements. This future-looking information 
+          comes with an associated uncertainty, as fully described for each 
+          design value element in ECCC’s recent Climate Resilient Buildings 
+          and Core Public Infrastructure report (Cannon et al., 2020), 
+          which should be consulted for further guidance. 
 
-      - header: Version
-        body: '{DVE_VERSION}'
+          In brief, Tier 1 variables are those for which there is generally 
+          high or very high confidence in the future projections for a given 
+          level of global warming. These variables reflect the well-understood 
+          thermal response of the climate to external radiative forcing of 
+          the Earth system, and include:
+            - heating degree days
+            - hourly design temperatures (January 2.5% dry bulb, January 1% dry bulb, July 2.5% dry bulb, and July 2.5% wet bulb)
+            - maximum and minimum mean daily air temperatures
+          
+          Tier 2 variables are those for which there is generally medium 
+          confidence in the future projections for a given level of global 
+          warming, and include:
+            - annual total precipitation and annual total rainfall
+            - annual maximum 1-day rain (50-yr return period)
+            - annual maximum 15-min rainfall (10-yr return period)
+            - IDF CFs
+          
+          Tier 3 variables are those for which there is low or very low 
+          confidence in the future projections for a given level of global 
+          warming, and include:
+            - annual mean relative humidity
+            - annual maximum hourly wind pressures (10, 25, 50, and 100-yr return periods)
+            - annual maximum driving rain wind pressures (5-yr return period)
+            - annual maximum snow load & rain-on-snow load (50-yr return period)
+            - moisture index
+            
+          Reference
+          
+          Cannon, A. J., et al. 2020: _Climate-resilient buildings and core 
+          public infrastructure 2020: An assessment of the impact of climate 
+          change on climatic design data in Canada._
+          https://publications.gc.ca/site/eng/9.893021/publication.html
 
-      - header: Author
-        body: '[Pacific Climate Impacts Consortium (PCIC)](https://pacificclimate.org/)'
-
-      - header: Terms of Use
-        body: Please see PCIC's [terms of use](https://pacificclimate.org/terms-of-use).
 
       - header: No Warranty
         color: warning
@@ -25,6 +66,15 @@ tabs:
           your own risk. In no event will the Pacific Climate Impacts Consortium be liable for any loss or damage
           whatsoever, including, without limitation, indirect or consequential loss or damage, arising from reliance
           upon the data or derived information.
+
+      - header: Version
+        body: '{DVE_VERSION}'
+
+      - header: Author
+        body: '[Pacific Climate Impacts Consortium (PCIC)](https://pacificclimate.org/)'
+
+      - header: Terms of Use
+        body: Please see PCIC's [terms of use](https://pacificclimate.org/terms-of-use).
 
       - header: Methods
         body: |

--- a/config/about.yml
+++ b/config/about.yml
@@ -26,6 +26,10 @@ tabs:
           whatsoever, including, without limitation, indirect or consequential loss or damage, arising from reliance
           upon the data or derived information.
 
+      - header: Methods
+        body: |
+          [Methods used to derive design values](https://pacificclimate.org/)
+
   - label: Credits
     cards:
       - header: Development
@@ -44,8 +48,6 @@ tabs:
         body: |
           Please address questions about science and interpretation of the
           data presented in this tool to [Regional Climate Impacts](mailto:climate@uvic.ca).
-      - header: Pacific Climate Impacts Consortium
-        body: See [PCIC Contact page](https://pacificclimate.org/contact-us).
 
   - label: Team
     cards:
@@ -54,7 +56,7 @@ tabs:
       - header: '[James Hiebert](https://pacificclimate.org/about-pcic/people/james-hiebert)'
         body: Development team lead.
       - header: '[Rod Glover](https://pacificclimate.org/about-pcic/people/rod-glover)'
-        body: Developer.
+        body: Frontend development lead.
       - header: '[Matthew Benstead](https://pacificclimate.org/about-pcic/people/matthew-benstead)'
         body: System administrator. Deployment and security.
       - header: Nic Annau

--- a/config/help/intro.yml
+++ b/config/help/intro.yml
@@ -1,33 +1,74 @@
 |
-  This page contains information on how to use the application's user
+  The Help tab contains information on how to use the application's user
   interface. For information on interpreting values and on the science and
   methods behind the data presented in Design Value Explorer, see XXX.
 
   ## Overview
 
-  Design Value Explorer (DVE) enables you to view and download design values
-  from both historical and future projected data sets.
+  Design Value Explorer (DVE) enables enables users to access historical
+  design variables across Canada, in either map or table form, examine
+  projected future change in design variables, and download maps and tables.
 
-  - For historical datasets, there are both observations (station data at
-    specific locations) and interpolated rasters covering most of Canada.
+  - For the historical period, there are both observations (station data at
+    specific locations) and interpolated rasters covering all of Canada.
 
-  - Future projected datasets are rasters covering most of Canada. Each
-    future projected dataset is characterized by a global warming level
+  - For future periods, projections are rasters covering most of Canada. Each
+    future projection is characterized by a global warming level
     in °C above baseline (e.g., 2.0 °C).
 
   ## Main tabs
 
-  DVE presents this data in two ways: As a map and in "Table C-2" format,
+  DVE presents the design data in two ways: As maps and in tabular format,
   under the **Map** and **Table C-2** tabs respectively.
 
-  - The map always shows the rasters (historical or future), and can show an
-    overlay of station observations for historical datasets.
+  - The Map tab shows the interpolated rasters (historical or future), with the
+    option of overlaying station observations for the historical period.
 
-  - Table C-2 always shows both historical and future projected datasets at
-    a set of station locations across Canada.
+  - The Table C-2 tab presents both historical and future projected design values
+    at a set of standard locations compiled in the National Building Code of
+    Canada.
+
+  The **Help** and **About** tabs contain supplementary information
+  about DVE.
 
   ## Design Variable selection
 
-  DVE displays data for exactly one design variable at a time. Select the
-  DV of interest with the **Design Variable** drop-down. This selection
-  applies to both the **Map** tab and the **Table C-2** tab.
+  For both tabs, DVE displays data for one design variable at a time, which is
+  selected from the Design Variable drop-down menu.
+
+  ## Local storage of your preferences
+
+  DVE "remembers" the value of various options you select. In this way,
+  it builds up a local database of your preferences for viewing the data.
+  (This preference information is stored locally in your browser. There is
+  no way for DVE to know who you are apart from the browser you are using.)
+
+  For example, when you select a Colour Map for
+  a map display, DVE stores that selection in association with the currently
+  selected Design Variable and Period. Whenever you select that particular
+  combination of DV and Period again, the stored Colour Map for that
+  combination is set.
+
+  All options start out with default settings. As you use the app,
+  default settings are replaced by your preferences.
+
+  Preference storage persists between sessions with DVE, so your preferences
+  persist even if you close the DVE browser window or refresh the page.
+
+  The following options are managed as preferences:
+
+  | Tab | Option | Associated with |
+  | ----- | --- | --- |
+  | -     | Main tab selection | - |
+  | Map   | Period | - |
+  | Map   | Global Warming | - |
+  | Map   | Stations | - |
+  | Map   | Grid | - |
+  | Map   | Colour Map | Design Variable; Period |
+  | Map   | Scale | Design Variable; Period |
+  | Map   | Num. Colours | Design Variable; Period |
+  | Help  | Secondary tab selection | - |
+  | About | Secondary tab selection | - |
+
+  Note: The associations for each option (particularly Map options) have
+  been selected with with maximum utility for viewing the data in mind.

--- a/config/help/intro.yml
+++ b/config/help/intro.yml
@@ -57,7 +57,7 @@
 
   The following options are managed as preferences:
 
-  | Tab | Option | Associated with |
+  | On tab | Option | Associated with |
   | ----- | --- | --- |
   | -     | Main tab selection | - |
   | Map   | Period | - |
@@ -70,5 +70,7 @@
   | Help  | Secondary tab selection | - |
   | About | Secondary tab selection | - |
 
-  Note: The associations for each option (particularly Map options) have
-  been selected with with maximum utility for viewing the data in mind.
+  Note: The associations for each option have
+  been selected for maximum utility in viewing data. This means, for example,
+  that Overlay Options are not associated with DV and Period, but Colour Scale
+  Options are.

--- a/config/help/map.yml
+++ b/config/help/map.yml
@@ -1,15 +1,10 @@
 |
-  The **Map** tab presents values of the selected design variable in a
-  map-like format. We say "map-like" advisedly; this is not a web mapping
-  application like
-  Google Maps with a fixed map projection. Instead, it is a graph
-  with longitude and latitude as the
-  horizontal and vertical axes respectively. Its appearance is approximately
-  an orthographic projection, but its aspect ratio changes with the size
-  of the display window it is in and with the region selected when
-  zooming in. If you select a region with an aspect ratio far from 4:3,
-  its appearance will be somewhat strange, although still accurate
-  to the data.
+  The Map tab displays the selected design value in
+  map form. The display resemble a Lambert azimuthal projection,
+  but the aspect ratio changes depending on the browser used and, of course,
+  whether and how the zoom feature is activated.
+  Keep in mind that this is not a web mapping
+  application like Google Maps with a fixed map projection.
 
   The content of the map is controlled by two sets of controls:
 
@@ -20,18 +15,15 @@
 
   ## Overlay Options
 
-  "Overlay options" refers to the overlays or layers presented in the
-  map display. The overlays available are:
+  "Overlay" refers to the overlays or layers presented in the
+  map display.
 
-  - Geographic boundaries (always present) of major features of Canada.
-  - Raster (always present) of interpolated historical
-    values or future projected values, presented as a heatmap, which is to
-    say presented with the value of each raster cell represented by a
-    colour defined by the colour scale you select.
-  - Station design values (for historical data only), presented as circle
+  - Geographic boundaries and colour raster are always present.
+  - Station design values (for historical data only) can be overlaid.
+    They are presented as circle
     markers on the map with the value of the design variable at that
     station represented by a colour as for the raster.
-  - Lon-lat reference grid.
+  - A longitude-latitude reference grid can be overlaid.
 
   ### Raster
 
@@ -39,6 +31,8 @@
 
   1. Click the **Historical design values** radio
      button under **Period** in the **Overlay Options** section.
+  2. The map displays the selected design value field. The map title indicates
+     the units of the design values.
 
   To display a raster of future projected data:
 
@@ -46,6 +40,12 @@
      **Period** in the **Overlay Options** section.
   2. Select the level of global warming in the
      dropdown under **Global Warming** in the **Overlay Options** section.
+  3. The map displays the changes from the historical period at the chosen
+     Global Warming level.
+     - For temperature-based variables, change values are
+       additive and in units of the original variable.
+     - For other variables, change values are multiplicative factors and their
+       units are indicated as "ratio".
 
   For information on controlling the colour scale applied to the rasters,
   see Colour Scale Options below.
@@ -55,86 +55,55 @@
 
   ### Station locations
 
-  Stations are the fundamental source of data (observations) for design
-  values based on historical data. To see the stations displayed as
-  circular markers on the map:
-
-  1. Slide the **Stations** switch to the right ("on" position).
+  Stations are the fundamental source of data for historical design values.
+  To see the stations displayed as circular markers on the map, slide the
+  **Stations** switch to the right ("on" position).
 
   For information on controlling the colour scale applied to the station
   markers, see Colour Scale Options below.
 
-  ### Lon-lat grid
+  ### Longitude-latitude grid
 
   A grid marking longitude and latitude can be overlaid on the map.
-  The grid adjusts its spacing depending on how far in our out the map
+
+  To display the longitude-latitude grid, slide the **Grid** switch to the
+  right ("on" position).
+
+  The grid adjusts its spacing depending on how far in or out the map
   is zoomed.
-
-  To display the lon-lat grid:
-
-  1. Slide the **Grid** switch to the right ("on" position).
 
   ## Colour Scale Options
 
   Colour scale options control how the raster and station data
   values are displayed as colour in the map.
 
-  How it works:
-  - Choose a _colour map_. This determines the fundamental set of
-    colours used to build the colour scale.
-  - Choose a _scale_. This determines whether the colour scale is
-    linear or logarithmic, meaning whether adjacent colours in the
-    resulting colour scale represent values that advance linearly or
-    geometrically. This is analogous to linear or logarithmic scales in
-    numerical graph axes.
-  - Choose a _number of colours_. This determines how many different
+  Summary:
+  - Colour Map determines the fundamental set of
+  colours used to build the colour scale.
+  - Scale determines whether data values are mapped to the colour scale
+  linearly or logarithmically.
+  - Number of Colours determines how many different
     colours are in the resulting colour scale.
-  - Choose a _data range_. This determines what range of data values are
-    represented as colour scale colours. Data values outside this range
-    are represented as transparent.
-  - A _colour scale_ is formed using the above information. This is a set
-    of discrete, _uniformly spaced_ (see note below) value intervals that
-    span the _data range_. The number of intervals is set by _number of
-    colours_. That same number of colours are interpolated from the _colour
-    map_ and assigned in sequence to each successive interval. Data
-    values are coloured according to which value interval they fall into.
-    Data values below/above the _data range_ minimum/maximum are
-    represented as the lowest/highest value colour.
-    Missing data values are represented as transparent.
-  - _Uniform spacing_: For a linear scale, uniform spacing means colour
-    intervals that are linearly spaced between minimum and maximum. For a
-    logarithmic scale, uniform spacing means colour intervals that are
-    geometrically spaced between minimum and maximum (equivalently, the
-    data values and intervals are transformed to their logarithms, and the
-    logarithms are linearly spaced).
+  - Data Range determines what range of data values are
+    represented as colour scale colours.
 
   ### Notes
 
   The boundaries of the data intervals in the colour scale are
-  _uniformly spaced_ (see above) between the range minimum and
-  maximum values, and fall on whatever arbitrary values this yields.
-  Exceptions to this rule are:
+  uniformly spaced (linearly or logarithmically) between the range minimum and
+  maximum values. Additionally:
 
-  1. "Targeted" boundary value:
+  1. "Targeted" boundary value: A target makes it easy to distinguish
+     the "no change" condition by colour, particularly with a small
+     number of colours.
      - For future datasets (which contain _relative change_ values),
      - a target of 0 (for absolute change) or 1 (for ratio change) is
        selected,
      - if the target value lies in the selected data range;
        otherwise no target is selected.
 
-     Why have targets? Because a target makes it easy to distinguish
-     the "no change" condition by colour, particularly with a small
-     number of colours in the colour scale.
-
-     If a target is selected, boundary values are shifted by the minimum
-     possible amount so
-     that one boundary value is exactly the target value. This may
-     require adding an extra interval (with the same uniform spacing)
-     to the beginning or end of the scale to cover the full data range.
-  2. Logarithmic scale with zero minimum value: A logarithmic scale
-     cannot represent a zero value. In this case, the minimum value is
-     adjusted to be a fixed fraction (typically 1/100) of the maximum
-     value.
+  2. Logarithmic scale with zero minimum data value: The minimum value is
+     adjusted to a fixed fraction (typically 1/100) of the maximum value.
 
   ### Colour Map
 
@@ -147,15 +116,15 @@
 
   ### Scale
 
-  Select linear or logarithmic colour mapping. Some selections of Design
+  Select Linear or Logarithmic colour mapping. Some selections of Design
   Value and Period do not permit logarithmic scales; in this case the
   selector is disabled and the scale is fixed at linear.
 
   ### Num. Colours
 
   Select the number of colours in the colour scale by dragging the
-  pointer. Smaller numbers of colours give a contour effect in the map
-  display, which can be useful to identify particular values of interest.
+  pointer. Smaller numbers of colours give a contour effect,
+  which can be useful to identify particular values of interest.
   Larger numbers of colours give a continuous gradient effect.
 
   ### Range
@@ -163,7 +132,8 @@
   Select the range of data values to be coloured.
   Data values below/above the data range minimum/maximum are
   represented as the lowest/highest value colour.
-  Missing data values are represented as transparent.
+  Missing data values are represented as transparent, which means that the
+  map background colour shows through.
 
   ## Map display
 
@@ -231,10 +201,5 @@
   ### Downloading click data
 
   When you have clicked on a cell to display location and Design Variable
-  values, you can download this information as a (single) CSV file.
-
-  1. Click the **Download this data** button.
-  2. A **Save as file** dialog pops up.
-  3. Select the location and filename for the file in which to save the data.
-  4. Click **Save**.
-  5. The data is saved in a CSV file and the dialog closes.
+  values, you can download this information as a (single) CSV file by
+  clicking the **Download this data** button.

--- a/config/help/table_C2.yml
+++ b/config/help/table_C2.yml
@@ -7,12 +7,13 @@
   the change factors (CF), relative to the reference period, at the specified
   levels of global warming.
 
-  - For temperature-based variables, the CFs are additive and in units of
-    the original variable.
-  - For all other variables, the CFs are multiplicative factors.
+  - For temperature-based variables, the change factors are additive and
+    in units of the original variable.
+  - For all other variables, the change factors are multiplicative and
+    hence unitless.
 
   There are some gaps in the Tables in this version of DVE:
 
-  - Future CFs for MI are not available at this time.
-  - IDFCF, RHAnn, Tmax and Tmin are not part of the NBCC, but were produced
-    for the DVE.
+  - Future change factors for MI are not available at this time.
+  - Design variables IDFCF, RHAnn, Tmax and Tmin are not part of the NBCC,
+    but were produced for the DVE.

--- a/config/help/table_C2.yml
+++ b/config/help/table_C2.yml
@@ -1,1 +1,18 @@
-Table C-2 help
+|
+  Design values are provided at locations specified by geographic location in
+  the NBCC Table C-2 and gathered by province. The  **NBCC** column gives the
+  value from the most recent edition of the Code (current up to 2020),
+  the **PCIC** column gives the value extracted from the DVE map for the
+  historical reference period (1986-2016); and the remaining columns contain
+  the change factors (CF), relative to the reference period, at the specified
+  levels of global warming.
+
+  - For temperature-based variables, the CFs are additive and in units of
+    the original variable.
+  - For all other variables, the CFs are multiplicative factors.
+
+  There are some gaps in the Tables in this version of DVE:
+
+  - Future CFs for MI are not available at this time.
+  - IDFCF, RHAnn, Tmax and Tmin are not part of the NBCC, but were produced
+    for the DVE.

--- a/config/local_preferences.yml
+++ b/config/local_preferences.yml
@@ -1,6 +1,6 @@
 # For documentation of this config, see dve/callbacks/local_preferences.py
 
-version: 17
+version: 19
 path_separator: ";"
 function_marker: "@"
 ui_elements:
@@ -21,6 +21,14 @@ ui_elements:
   - selector: about_tabs.active_tab
     paths:
       global: ui;controls;about_tabs;active_tab
+
+  - selector: climate_regime.value
+    paths:
+      global: ui;controls;climate-regime;value
+
+  - selector: future_dataset_id.value
+    paths:
+      global: ui;controls;future-dataset;value
 
   - selector: show_stations.on
     inputs:

--- a/dve/assets/style.css
+++ b/dve/assets/style.css
@@ -10,3 +10,16 @@
 #global_warming label {
     margin: 0.5em 0;
 }
+
+.about_tab table,
+.help_tab table
+{
+    margin-bottom: 1rem;
+}
+
+.about_tab td, .about_tab th,
+.help_tab td, .help_tab th
+{
+    border: 1px solid lightgray;
+    padding: 0 0.5em;
+}

--- a/dve/callbacks/map_figure.py
+++ b/dve/callbacks/map_figure.py
@@ -158,10 +158,14 @@ def add(app, config):
         # Show info message if design values for requested climate regime do not
         # exist.
         if raster_filepath is None:
+            what = {
+                "historical": "historical values",
+                "future": "future projections",
+            }[climate_regime]
             return message_figure(
-                f"No {climate_regime} data is available for "
-                f"{dv_name(config, design_variable)}. "
-                f"This is an intentional omission."
+                f"No {what} are available for "
+                f"{dv_name(config, design_variable)} "
+                f"at this time."
             )
 
         # Show error message if configured data file does not exist.

--- a/dve/callbacks/map_pointer.py
+++ b/dve/callbacks/map_pointer.py
@@ -8,7 +8,7 @@ from dash.exceptions import PreventUpdate
 from dash import html
 import dash_bootstrap_components as dbc
 
-from dve.config import dv_has_climate_regime
+from dve.config import dv_has_climate_regime, filepath_for
 from dve.data import get_data_object
 from dve.download_utils import (
     download_filename,
@@ -142,6 +142,9 @@ def value_table(*items):
     )
 
 
+historical_dataset_id = "reconstruction"
+
+
 def add(app, config):
     @functools.lru_cache(maxsize=10)
     def download_info(
@@ -181,8 +184,26 @@ def add(app, config):
         if hover_data is None or hover_data["points"][0]["curveNumber"] <= 1:
             return dash.no_update
 
-        historical_dataset_id = "reconstruction"
+        # Ignore if there is no data for the current design variable,
+        # climate regime and dataset (future GW, if future).
+        raster_filepath = filepath_for(
+            config,
+            design_variable,
+            climate_regime,
+            historical_dataset_id,
+            future_dataset_id,
+        )
+        if raster_filepath is None:
+            return None
 
+        # Clear if only the DV selection has changed
+        ctx = dash.callback_context
+        if ctx.triggered and ctx.triggered[0]["prop_id"].startswith(
+            "design_variable"
+        ):
+            return None
+
+        # TODO: This is likely irrelevant now -- see clear if no data.
         if not dv_has_climate_regime(config, design_variable, climate_regime):
             raise PreventUpdate
 
@@ -234,8 +255,26 @@ def add(app, config):
         if click_data is None or click_data["points"][0]["curveNumber"] <= 1:
             return dash.no_update
 
-        historical_dataset_id = "reconstruction"
+        # Ignore if there is no data for the current design variable,
+        # climate regime and dataset (future GW, if future).
+        raster_filepath = filepath_for(
+            config,
+            design_variable,
+            climate_regime,
+            historical_dataset_id,
+            future_dataset_id,
+        )
+        if raster_filepath is None:
+            return None
 
+        # Clear if only the DV selection has changed
+        ctx = dash.callback_context
+        if ctx.triggered and ctx.triggered[0]["prop_id"].startswith(
+            "design_variable"
+        ):
+            return None
+
+        # TODO: This is likely irrelevant now -- see clear if no data.
         if not dv_has_climate_regime(config, design_variable, climate_regime):
             raise PreventUpdate
 
@@ -287,15 +326,26 @@ def add(app, config):
         if click_data is None or click_data["points"][0]["curveNumber"] <= 1:
             return dash.no_update
 
-        historical_dataset_id = "reconstruction"
+        # Clear if there is no data for the current design variable,
+        # climate regime and dataset (future GW, if future).
+        raster_filepath = filepath_for(
+            config,
+            design_variable,
+            climate_regime,
+            historical_dataset_id,
+            future_dataset_id,
+        )
+        if raster_filepath is None:
+            return None
 
-        # If only the DV selection has changed, don't update.
+        # Clear if only the DV selection has changed
         ctx = dash.callback_context
         if ctx.triggered and ctx.triggered[0]["prop_id"].startswith(
             "design_variable"
         ):
-            raise PreventUpdate
+            return None
 
+        # TODO: This is likely irrelevant now -- see clear if no data.
         # If the selected DV doesn't cover the selected climate regime,
         # don't update.
         if not dv_has_climate_regime(config, design_variable, climate_regime):

--- a/dve/callbacks/overlay.py
+++ b/dve/callbacks/overlay.py
@@ -1,34 +1,11 @@
 import logging
-
-import dash
 from dash.dependencies import Input, Output
-
-from dve.config import dv_has_climate_regime
-from dve.layout import climate_regime_ctrl_options
 
 
 logger = logging.getLogger("dve")
 
 
 def add(app, config):
-    # @app.callback(
-    #     Output("climate_regime", "options"),
-    #     Output("climate_regime", "value"),
-    #     Input("design_variable", "value"),
-    # )
-    # def update_dataset_ctrl_value(design_variable):
-    #     """
-    #     If this DV does not have historical data, set climate regime
-    #     to future and disable historical option. Otherwise leave things alone.
-    #     """
-    #     if dv_has_climate_regime(config, design_variable, "historical"):
-    #         return climate_regime_ctrl_options(config), dash.no_update
-    #     options = [
-    #         {**option, "disabled": option["value"] == "historical"}
-    #         for option in climate_regime_ctrl_options(config)
-    #     ]
-    #     return options, "future"
-
     @app.callback(
         Output("future_dataset_id", "disabled"),
         [Input("climate_regime", "value")],

--- a/dve/callbacks/overlay.py
+++ b/dve/callbacks/overlay.py
@@ -11,23 +11,23 @@ logger = logging.getLogger("dve")
 
 
 def add(app, config):
-    @app.callback(
-        Output("climate_regime", "options"),
-        Output("climate_regime", "value"),
-        Input("design_variable", "value"),
-    )
-    def update_dataset_ctrl_value(design_variable):
-        """
-        If this DV does not have historical data, set climate regime
-        to future and disable historical option. Otherwise leave things alone.
-        """
-        if dv_has_climate_regime(config, design_variable, "historical"):
-            return climate_regime_ctrl_options(config), dash.no_update
-        options = [
-            {**option, "disabled": option["value"] == "historical"}
-            for option in climate_regime_ctrl_options(config)
-        ]
-        return options, "future"
+    # @app.callback(
+    #     Output("climate_regime", "options"),
+    #     Output("climate_regime", "value"),
+    #     Input("design_variable", "value"),
+    # )
+    # def update_dataset_ctrl_value(design_variable):
+    #     """
+    #     If this DV does not have historical data, set climate regime
+    #     to future and disable historical option. Otherwise leave things alone.
+    #     """
+    #     if dv_has_climate_regime(config, design_variable, "historical"):
+    #         return climate_regime_ctrl_options(config), dash.no_update
+    #     options = [
+    #         {**option, "disabled": option["value"] == "historical"}
+    #         for option in climate_regime_ctrl_options(config)
+    #     ]
+    #     return options, "future"
 
     @app.callback(
         Output("future_dataset_id", "disabled"),

--- a/dve/layout.py
+++ b/dve/layout.py
@@ -22,6 +22,8 @@ def card_item(card):
     header = card.get("header")
     body = card.get("body")
     return dbc.Card(
+        className="me-3 mb-3 float-start",
+        style={"width": "30%"},
         color=color,
         children=compact(
             (
@@ -34,6 +36,9 @@ def card_item(card):
 
 
 def card_set(cards, row_args={}, col_args={}):
+    return dbc.Row(
+        dbc.Col([card_item(card) for card in cards]), **row_args
+    )
     return dbc.Row(
         [dbc.Col(card_item(card), **col_args) for card in cards], **row_args
     )

--- a/dve/layout.py
+++ b/dve/layout.py
@@ -425,7 +425,7 @@ def main(app, config):
                             children=dbc.Row(
                                 dbc.Col(interpret(tab["content"]), xs=12, xl=6)
                             ),
-                            className="pt-3",
+                            className="help_tab pt-3",
                         )
                         for index, tab in enumerate(config["help"]["tabs"])
                     ],
@@ -449,7 +449,7 @@ def main(app, config):
                             tab["cards"],
                             col_args=dict(xs=12, md=6, xxl=4, className="mb-3"),
                         ),
-                        className="pt-3",
+                        className="about_tab pt-3",
                     )
                     for index, tab in enumerate(config["about"]["tabs"])
                 ],


### PR DESCRIPTION
- Resolves #207 
- Adds documentation for local preferences.
- Adds Period (climate regime) and Global Warming to local preferences.

- Improves behaviour on no data: 
  - Updates map message.
  - More significantly, clears Data from map pointer items when DV is changed. This prevents a lot of traffic to the backend when a user is just examining maps after having clicked a map location. It also ensures that the map-click location is always based on the current map, whose rasters--and hence click locations-- can differ.
  - Also fixes callback errors introduced by allowing no-data selections.
