### PR TITLE
upgrade github runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Export version env var
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish-production:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
         pip install -U pipenv
 
     - id: cache-pipenv
-      uses: actions/cache@v2
+      uses: actions/cache@v4.2.0
       with:
         path: ~/.local/share/virtualenvs
         key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,16 +5,15 @@ on: push
 jobs:
   test:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,11 +5,11 @@ on: push
 jobs:
   test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version:
-          - "3.7"
+          - "3.8"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,9 +6,19 @@ jobs:
   test:
 
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version:
+          - "3.6"
+          - "3.7"
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Design Value Explorer
 
+### *Note that the CI version of the tests is currently failing until this project goes through an upgrade cycle. [Upgrade Github Issue](https://github.com/pacificclimate/design-value-explorer/issues/242)*
+
 Web application for visualizing and downloading design value fields and 
 tables.
 
@@ -14,8 +16,6 @@ tables.
 - [Deployment for production](docs/deployment-prod.md)
 - [Testing](docs/testing.md)
 - [Dev notes](docs/dev-notes.md)
-
-### *Note that the CI version of the tests is currently failing until this project goes through an upgrade cycle.*
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ tables.
 - [Testing](docs/testing.md)
 - [Dev notes](docs/dev-notes.md)
 
+### *Note that the CI version of the tests is currently failing until this project goes through an upgrade cycle.*
+
 ## Changelog
 
 For a summary of releases and changes, see [`NEWS.md`](NEWS.md).

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(
 Intended Audience :: Science/Research
 License :: GNU General Public License v3 (GPLv3)
 Operating System :: OS Independent
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Topic :: Scientific/Engineering
 Topic :: Software Development :: Libraries :: Python Modules""".split(
         "\n"


### PR DESCRIPTION
Fix up github actions.
- Bump ubuntu version from 20.04 (deprecated) to 24.04
- Update version actions to latest